### PR TITLE
[#11] Handle empty action creator invocations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-modules",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "A library for defining clear, boilerplate free Redux reducers.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/payloadPropchecker.js
+++ b/src/payloadPropchecker.js
@@ -2,9 +2,8 @@ import { curry, keys, forEach, compose } from 'ramda';
 
 const defaultPropCheck = () => { return {}; };
 
-export const propCheckedPayloadCreator = curry(
-  ({actionName, payloadTypes, onError}, payload) => {
-
+export const propCheckedPayloadCreator = ({actionName, payloadTypes, onError}) =>
+  payload => {
     const _propCheck = type => {
       const propChecker = payloadTypes[type] || defaultPropCheck;
       const typeError = propChecker(payload, type, actionName, 'prop') || {};
@@ -20,6 +19,5 @@ export const propCheckedPayloadCreator = curry(
 
     return payload;
   }
-);
 
 export default propCheckedPayloadCreator;

--- a/tests/createActions-test.js
+++ b/tests/createActions-test.js
@@ -2,15 +2,15 @@ import { expect, should } from 'chai';
 import createActions from '../src/createActions';
 should();
 const mockTransforms = [
-  { action: 'MOCK_ONE' },
-  { action: 'MOCK_TWO' },
+  { formattedConstant: 'mock/MOCK_ONE', action: 'MOCK_ONE' },
+  { formattedConstant: 'mock/MOCK_ONE', action: 'MOCK_TWO' },
 ];
 
 describe('createActions', () => {
-  describe('generated hash', () => {
-    const generatedActions = createActions(mockTransforms);
-    const firstKey = Object.keys(generatedActions)[0];
+  const generatedActions = createActions(mockTransforms);
+  const firstKey = Object.keys(generatedActions)[0];
 
+  describe('generated hash', () => {
     it('should return a hash', () => {
       (typeof generatedActions === 'object').should.equal(true);
     });
@@ -20,6 +20,34 @@ describe('createActions', () => {
     it('generates the same number of actions as transformations', () => {
       const numberOfActions = Object.keys(generatedActions).length;
       numberOfActions.should.equal(mockTransforms.length);
+    });
+  });
+
+  describe('generated action', () => {
+    const actionToTest = generatedActions[firstKey];
+    const result = actionToTest({foo: 'bar'});
+
+    it('should contain a type key whose value is a well formatted action constant', () => {
+      result.type.should.equal('mock/MOCK_ONE');
+    });
+
+    it('should handle object payloads', () => {
+      result.payload.should.deep.equal({foo: 'bar'});
+    });
+
+    it('should handle null payloads', () => {
+      const nullTest = actionToTest(null);
+      expect(nullTest.payload).to.equal(null);
+    });
+
+    it('should handle empty payloads', () => {
+      const nullTest = actionToTest(null);
+      expect(nullTest.payload).to.not.exist;
+    });
+
+    it('should handle numeric payloads', () => {
+      const numberTest = actionToTest(5);
+      expect(numberTest.payload).to.equal(5);
     });
   });
 });

--- a/tests/createActions-test.js
+++ b/tests/createActions-test.js
@@ -41,7 +41,7 @@ describe('createActions', () => {
     });
 
     it('should handle empty payloads', () => {
-      const nullTest = actionToTest(null);
+      const nullTest = actionToTest();
       expect(nullTest.payload).to.not.exist;
     });
 


### PR DESCRIPTION
### Description
When an action creator is called with no parameters eg: `mock.actions.mockAction()`, the `payload` in the action object generated is a `function` instead of `undefined`.

### Issue
The issue comes from the use of ramda's `curry`. Calling a curried function with no parameters doesn't actually invoke the function as expected.

Fixes #11 