### PR TITLE
this adds the ability to specify meta attributes in transformations 

### DIFF
--- a/src/createModule/createActions.js
+++ b/src/createModule/createActions.js
@@ -14,13 +14,15 @@ const _generateActions = (generatedActions, transformation) => {
   const {
     action,
     payloadTypes = {},
+    meta,
     formattedConstant: actionName,
   } = transformation;
   const camelizedActionName = camelize(action);
 
   generatedActions[camelizedActionName] = createAction(
     actionName,
-    payloadPropchecker({actionName, payloadTypes, onError})
+    payloadPropchecker({actionName, payloadTypes, onError}),
+    () => meta
   );
 
   return generatedActions;

--- a/tests/createModule/createActions-test.js
+++ b/tests/createModule/createActions-test.js
@@ -4,11 +4,20 @@ should();
 const mockTransforms = [
   { formattedConstant: 'mock/MOCK_ONE', action: 'MOCK_ONE' },
   { formattedConstant: 'mock/MOCK_ONE', action: 'MOCK_TWO' },
+  {
+    formattedConstant: 'mock/MOCK_THREE',
+    action: 'MOCK_THREE',
+    meta: {
+      foo: 'bar',
+    },
+  },
 ];
 
 describe('createActions', () => {
   const generatedActions = createActions(mockTransforms);
-  const firstKey = Object.keys(generatedActions)[0];
+  const keys = Object.keys(generatedActions)
+  const firstKey = keys[0];
+  const lastKey = keys.slice(-1);
 
   describe('generated hash', () => {
     it('should return a hash', () => {
@@ -25,7 +34,9 @@ describe('createActions', () => {
 
   describe('generated action', () => {
     const actionToTest = generatedActions[firstKey];
+    const actionWithMeta = generatedActions[lastKey];
     const result = actionToTest({foo: 'bar'});
+    const resultWithMeta = actionWithMeta({foo: 'bar'});
 
     it('should contain a type key whose value is a well formatted action constant', () => {
       result.type.should.equal('mock/MOCK_ONE');
@@ -48,6 +59,14 @@ describe('createActions', () => {
     it('should handle numeric payloads', () => {
       const numberTest = actionToTest(5);
       expect(numberTest.payload).to.equal(5);
+    });
+
+    it('should not contain a meta key if not specified', () => {
+      expect(result.meta).to.not.exist;
+    });
+
+    it('should contain a meta key if specified', () => {
+      resultWithMeta.meta.should.deep.equal({foo: 'bar'});
     });
   });
 });


### PR DESCRIPTION
#### Summary
FSA specifies the `meta` tag that should sit beside the payload. this PR adds the ability to specify a `meta` object in the transformations.

#### Example
```
export const { actions, reducer, constants } = createModule({
  name: 'foo',
  transformations: [
    {
      action: 'FETCH',
      meta: {
        foo: 'bar'
      },
      payloadTypes: {
        id: oneOfType([string, number]),
      },
      reducer: (state, {payload: {id}}) => {
      },
    },
...
```

#### Reading
https://github.com/acdlite/flux-standard-action
https://github.com/acdlite/redux-actions#createactiontype-payloadcreator--identity-metacreator `metaCreator`

#### Other PRs
https://github.com/mboperator/redux-modules/pull/20