### PR TITLE
Use props.dispatch first, or fallback to normal dispatch

### DIFF
--- a/src/connectModule/connectModules.js
+++ b/src/connectModule/connectModules.js
@@ -6,10 +6,15 @@ import combineNamespacedProps from './combineNamespacedProps';
 
 const { func } = PropTypes;
 
-const nestedBindDispatch = modules => dispatch =>
+const nestedBindDispatch = modules => (dispatch, props) =>
   modules.reduce((bna, { name, actions }) => {
     // eslint-disable-next-line no-param-reassign
-    bna[name] = { actions: bindActionCreators(actions, dispatch) };
+    bna[name] = {
+      actions: bindActionCreators(
+        actions,
+        props.dispatch || dispatch
+      ),
+    };
     return bna;
   }, {});
 


### PR DESCRIPTION
### Description
Components wrapped with `connectModule` will look at `props.dispatch` as well as `dispatch` when attempting to bind their actions, allowing the parent module to optionally pass a decorated dispatch. This change is meant to be used with reducer composition.