### PR TITLE
Internalize connect.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
   "license": "ISC",
   "dependencies": {
     "camel-case": "^1.2.2",
-    "deep-assign": "^2.0.0"
+    "deep-assign": "^2.0.0",
+    "hoist-non-react-statics": "^1.2.0"
   },
   "peerDependencies": {
-    "react-redux": "^4.4.1",
     "redux": "^3.3.1"
   },
   "devDependencies": {

--- a/src/connectModule/combineNamespacedProps.js
+++ b/src/connectModule/combineNamespacedProps.js
@@ -1,7 +1,0 @@
-import deepAssign from 'deep-assign';
-
-const createNamespacedProps =
-  (mapStateProps, mapDispatchProps, props) =>
-    deepAssign({}, mapStateProps, mapDispatchProps, props);
-
-export default createNamespacedProps;

--- a/src/connectModule/index.js
+++ b/src/connectModule/index.js
@@ -1,13 +1,13 @@
 import connectModules from './connectModules';
 
-const createSelectorOrDefault = ({ name, selector }) => {
+export const createSelectorOrDefault = ({ name, selector }) => {
   if (typeof selector === 'function') {
     return selector;
   }
   return state => state[name];
 };
 
-const createModuleSelector = modules => {
+export const createModuleSelector = modules => {
   if (modules.length === 1) {
     return createSelectorOrDefault(modules[0]);
   }
@@ -38,7 +38,7 @@ export const connectModule = (selector, modules) => {
     formattedSelector = selector;
     formattedModules = Array.isArray(modules) ? modules : [modules];
   }
-  return Component => connectModules(formattedSelector, formattedModules, Component);
+  return connectModules(formattedSelector, formattedModules);
 };
 
 export default connectModule;

--- a/src/moduleProvider/index.js
+++ b/src/moduleProvider/index.js
@@ -1,29 +1,26 @@
-﻿import React, { PropTypes } from 'react';
-import { Provider } from 'react-redux';
+﻿import { Children, Component, PropTypes } from 'react';
 import { combineReducers } from 'redux';
 
 import registerModule from './registerModule';
 
-export default class ModuleProvider extends React.Component {
+import storeShape from '../utils/storeShape';
+
+export default class ModuleProvider extends Component {
   static propTypes = {
     children: PropTypes.element.isRequired,
     combineReducers: PropTypes.func,
     staticReducers: PropTypes.object,
-    // Alternatively, you could pull "storeShape" from "react-redux"
-    store: PropTypes.shape({
-      subscribe: PropTypes.func.isRequired,
-      dispatch: PropTypes.func.isRequired,
-      getState: PropTypes.func.isRequired,
-    }).isRequired,
+    store: storeShape.isRequired,
   };
 
   static childContextTypes = {
-    registerModule: PropTypes.func,
+    registerModule: PropTypes.func.isRequired,
+    store: storeShape.isRequired,
   };
 
   constructor(props, context) {
     super(props, context);
-    // <Provider> does not support changing "store", so "store" should always be the same instance
+    this.store = props.store;
     this.registerModule = registerModule(
       props.store,
       props.combineReducers || combineReducers,
@@ -33,15 +30,11 @@ export default class ModuleProvider extends React.Component {
   getChildContext() {
     return {
       registerModule: this.registerModule,
+      store: this.store,
     };
   }
 
   render() {
-    const { store, children } = this.props;
-    return (
-      <Provider store={store}>
-        {children}
-      </Provider>
-    );
+    return Children.only(this.props.children);
   }
 }

--- a/src/selectors/getFinalProps.js
+++ b/src/selectors/getFinalProps.js
@@ -1,0 +1,25 @@
+﻿import mergeProps from './mergeProps';
+
+export const createFinalPropsSelector = ({ getState, getDispatch }) => {
+  let lastOwn;
+  let lastState;
+  let lastMerged;
+  let dispatch;
+  return (state, props) => {
+    const nextOwn = props;
+    const nextState = getState(state, props);
+
+    if (typeof dispatch === 'undefined') {
+      dispatch = getDispatch(props);
+    }
+
+    if (lastOwn !== nextOwn || lastState !== nextState) {
+      lastMerged = mergeProps(nextState, dispatch, nextOwn);
+      lastOwn = nextOwn;
+      lastState = nextState;
+    }
+    return lastMerged;
+  };
+};
+
+export default createFinalPropsSelector;

--- a/src/selectors/mergeProps.js
+++ b/src/selectors/mergeProps.js
@@ -1,0 +1,7 @@
+﻿import deepAssign from 'deep-assign';
+
+export const mergeProps =
+  (stateProps, dispatchProps, ownProps) =>
+    deepAssign({}, stateProps, dispatchProps, ownProps);
+
+export default mergeProps;

--- a/src/utils/Subscription.js
+++ b/src/utils/Subscription.js
@@ -1,0 +1,54 @@
+﻿export default class Subscription {
+  constructor(store, parentSub, onStateChange) {
+    this.subscribe = parentSub
+      ? parentSub.addNestedSub.bind(parentSub)
+      : store.subscribe;
+
+    this.onStateChange = onStateChange;
+    this.lastNestedSubId = 0;
+    this.unsubscribe = null;
+    this.nestedSubs = {};
+
+    this.notifyNestedSubs = this.notifyNestedSubs.bind(this);
+  }
+
+  addNestedSub(listener) {
+    this.trySubscribe();
+
+    const id = ++this.lastNestedSubId;
+    this.nestedSubs[id] = listener;
+    return () => {
+      if (this.nestedSubs[id]) {
+        delete this.nestedSubs[id];
+      }
+    };
+  }
+
+  isSubscribed() {
+    return Boolean(this.unsubscribe);
+  }
+
+  notifyNestedSubs() {
+    const keys = Object.keys(this.nestedSubs);
+    for (let i = 0; i < keys.length; ++i) {
+      this.nestedSubs[keys[i]]();
+    }
+  }
+
+  trySubscribe() {
+    if (this.unsubscribe) {
+      return;
+    }
+
+    this.unsubscribe = this.subscribe(() => {
+      this.onStateChange(this.notifyNestedSubs);
+    });
+  }
+
+  tryUnsubscribe() {
+    if (this.unsubscribe) {
+      this.unsubscribe();
+    }
+    this.unsubscribe = null;
+  }
+}

--- a/src/utils/memoizeProps.js
+++ b/src/utils/memoizeProps.js
@@ -1,0 +1,17 @@
+﻿import shallowEqual from './shallowEqual';
+
+export const memoizeProps = () => {
+  let lastProps;
+  let result;
+  return nextProps => {
+    if (lastProps !== nextProps) {
+      if (!lastProps || !shallowEqual(lastProps, nextProps)) {
+        result = nextProps;
+      }
+      lastProps = nextProps;
+    }
+    return result;
+  };
+};
+
+export default memoizeProps;

--- a/src/utils/shallowEqual.js
+++ b/src/utils/shallowEqual.js
@@ -1,0 +1,22 @@
+﻿const hasOwn = Object.prototype.hasOwnProperty;
+
+export const shallowEqual = (objA, objB) => {
+  if (objA === objB) {
+    return true;
+  }
+  const keysA = Object.keys(objA);
+  const keysB = Object.keys(objB);
+  const lengthA = keysA.length;
+  if (lengthA !== keysB.length) {
+    return false;
+  }
+  for (let i = 0; i < lengthA; ++i) {
+    const key = keysA[i];
+    if (!hasOwn.call(objB, key) || objA[key] !== objB[key]) {
+      return false;
+    }
+  }
+  return true;
+};
+
+export default shallowEqual;

--- a/src/utils/storeShape.js
+++ b/src/utils/storeShape.js
@@ -1,0 +1,7 @@
+﻿import { PropTypes } from 'react';
+
+export default PropTypes.shape({
+  subscribe: PropTypes.func.isRequired,
+  dispatch: PropTypes.func.isRequired,
+  getState: PropTypes.func.isRequired,
+});


### PR DESCRIPTION
Internalizes `connect` from `react-redux`.  This avoids various issues with module registrations (i.e. `mapStateToProps` selecting `undefined` since the `reducer` has yet to be composed), removes the `react-redux` peerDependency, and probably boosts performance.