### PR TITLE
Removed undefined selector behavior

### DIFF
--- a/src/connectModule/index.js
+++ b/src/connectModule/index.js
@@ -1,10 +1,10 @@
 import connectModules from './connectModules';
 
-export const createSelectorOrDefault = ({ name, selector }) => {
+export const createSelectorOrDefault = ({ selector }) => {
   if (typeof selector === 'function') {
     return selector;
   }
-  return state => state[name];
+  return () => ({});
 };
 
 export const createModuleSelector = modules => {


### PR DESCRIPTION
### Description
`connectModules(todoModule)` will now return either use the default selector specified in the module or will return only the modules actions. The default behavior of returning `state[moduleName]` has been removed.

Removing the default is safer because we make no assumptions about how the `state` is shaped (eg the current method breaks if the root state is immutable) and it allows `connectModule` components to dispatch to the store without necessarily having to specify selectors.