### PR TITLE
Remove payloadPropchecker in production

### DIFF
--- a/src/createModule/index.js
+++ b/src/createModule/index.js
@@ -45,7 +45,7 @@ const parseTransformations = transformations => {
 export const createModule = ({ initialState, name, selector, transformations }) => {
   const defaultMiddleware = [parsePayloadErrors];
 
-  if (process.env.NODE_ENV === 'production') {
+  if (process.env.NODE_ENV !== 'production') {
     defaultMiddleware.push(payloadPropchecker());
   }
 

--- a/src/createModule/index.js
+++ b/src/createModule/index.js
@@ -43,7 +43,12 @@ const parseTransformations = transformations => {
 };
 
 export const createModule = ({ initialState, name, selector, transformations }) => {
-  const defaultMiddleware = [payloadPropchecker(), parsePayloadErrors];
+  const defaultMiddleware = [parsePayloadErrors];
+
+  if (process.env.NODE_ENV === 'production') {
+    defaultMiddleware.push(payloadPropchecker());
+  }
+
   const actions = {};
   const constants = {};
   const reducerMap = {};


### PR DESCRIPTION
## Closes #61 

Payload Propchecker should not be added in `production`. This `if` statement should be removed when Webpack transpiles.