### PR TITLE
Add reducer enhancers

### DIFF
--- a/docs/api_reference/REAMDE.md
+++ b/docs/api_reference/REAMDE.md
@@ -20,8 +20,14 @@ Used to prefix the actions defined in the `transformations` array, as well as na
 
 The initialState of this portion of the state tree.
 
+### reducerEnhancer
+> function
+
+> optional
+
+Allows use of a `reducerEnhancer` on the module. Examples include `redux-undo` and `redux-ignore`.
+
 ### transformations
 > array
 
 An array of objects that define state transformations.
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-modules",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A library for defining clear, boilerplate free Redux reducers.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/createModule/index.js
+++ b/src/createModule/index.js
@@ -5,6 +5,13 @@ import propCheck from '../middleware/propCheck';
 
 const defaultMiddleware = [parsePayloadErrors];
 
+const applyReducerEnhancer = (reducer, enhancer) => {
+  if (typeof enhancer === 'function') {
+    return enhancer(reducer);
+  }
+  return reducer;
+};
+
 const formatTransformation = (name, { action, type, ...transformation }) => ({
   formattedConstant: `${name}/${type || action}`,
   type: type || action,
@@ -40,7 +47,13 @@ const parseTransformations = transformations => {
   return finalTransformations;
 };
 
-export const createModule = ({ initialState, name, selector, transformations }) => {
+export const createModule = ({
+  initialState,
+  reducerEnhancer,
+  name,
+  selector,
+  transformations,
+}) => {
   const actions = {};
   const constants = {};
   const reducerMap = {};
@@ -73,7 +86,7 @@ export const createModule = ({ initialState, name, selector, transformations }) 
     const camelizedActionName = camelize(type);
     actions[camelizedActionName] = createAction(transformation, finalMiddleware);
     constants[camelizedActionName] = formattedConstant;
-    reducerMap[formattedConstant] = reducer;
+    reducerMap[formattedConstant] = applyReducerEnhancer(reducer, reducerEnhancer);
   }
   const reducer = (state = initialState, action) => {
     const localReducer = reducerMap[action.type];

--- a/tests/createModule/createModule-test.js
+++ b/tests/createModule/createModule-test.js
@@ -9,10 +9,15 @@ const mockTransforms = [
 ];
 
 describe('createModule', () => {
+  let enhancerCalled = false;
   const generatedModule = createModule({
     name: 'mock',
     // eslint-disable-next-line new-cap
     initialState: Map(),
+    reducerEnhancer: r => {
+      enhancerCalled = true;
+      return r;
+    },
     transformations: mockTransforms,
   });
   it('should generate an actions object', () => {
@@ -22,5 +27,8 @@ describe('createModule', () => {
   it('should generate a reducer function', () => {
     generatedModule.reducer.should.not.equal(null);
     (typeof generatedModule.reducer).should.equal('function');
+  });
+  it('should call the reducer enhancer function if specified', () => {
+    enhancerCalled.should.equal(true);
   });
 });


### PR DESCRIPTION
## Description
Adds `reducerEnhancer` key to `createModule`

## Example Usage
```js
import undoable from 'redux-undo';
const counterModule = createModule({
  name: 'counter',
  initialState: 0,
  reducerEnhancer: undoable,
  transformations: {
    'INCREMENT': state => state + 1,
    'DECREMENT': state => state - 1,
  },
});
```
## Closes #72 