### PR TITLE
Remove `action` deprecation warning on `transformations` object syntax.

### DIFF
--- a/src/createModule/index.js
+++ b/src/createModule/index.js
@@ -19,15 +19,15 @@ const formatTransformation = (name, { action, type, ...transformation }) => ({
   ...transformation,
 });
 
-const parseTransformation = (action, transformation) => {
+const parseTransformation = (type, transformation) => {
   if (typeof transformation === 'function') {
     return {
-      action,
+      type,
       reducer: transformation,
     };
   }
   return {
-    action,
+    type,
     ...transformation,
   };
 };


### PR DESCRIPTION
Using the object syntax for `transformations` was still using `action` instead of `type`, so it was giving a deprecation warning.