### PR TITLE
Support reducer composition

### DIFF
--- a/examples/dynamic-reducer/modules/todo.js
+++ b/examples/dynamic-reducer/modules/todo.js
@@ -1,4 +1,4 @@
-import { createModule } from '../../../src/index';
+import { createModule, middleware } from '../../../src/index';
 import { PropTypes } from 'react';
 import { fromJS, List } from 'immutable';
 
@@ -6,38 +6,43 @@ const { shape, number, string, bool } = PropTypes;
 
 export default createModule({
   name: 'todos',
-  // eslint-disable-next-line new-cap
-  initialState: List(),
+  initialState: List(), // eslint-disable-line new-cap
   transformations: [
     {
-      type: 'CREATE',
-      payloadTypes: {
-        todo: shape({
-          description: string.isRequired,
+      type: 'create',
+      middleware: [
+        middleware.propCheck({
+          todo: shape({
+            description: string.isRequired,
+            name: string.isRequired,
+          }),
         }),
-      },
+      ],
       reducer: (state, { payload: { todo } }) => state.push(fromJS(todo)),
     },
     {
-      type: 'DESTROY',
-      payloadTypes: {
-        index: number.isRequired,
-      },
+      type: 'destroy',
+      middleware: [
+        middleware.propCheck({
+          index: number.isRequired,
+          test: string.isRequired,
+        }),
+      ],
       reducer: (state, { payload: { index } }) => state.delete(index),
     },
     {
-      type: 'UPDATE',
-      payloadTypes: {
-        index: number.isRequired,
-        todo: shape({
-          description: string,
-          checked: bool,
+      type: 'update',
+      middleware: [
+        middleware.propCheck({
+          index: number.isRequired,
+          todo: shape({
+            description: string,
+            checked: bool,
+          }),
         }),
-      },
+      ],
       reducer: (state, { payload: { index, todo: updates } }) =>
-        state.update(
-          index,
-          todo => todo.merge(fromJS(updates))),
+        state.update(index, todo => todo.merge(fromJS(updates))),
     },
   ],
 });

--- a/examples/module-with-middleware/handlers/ModuleConnectedTodos.js
+++ b/examples/module-with-middleware/handlers/ModuleConnectedTodos.js
@@ -2,12 +2,7 @@ import todoModule from '../modules/todo';
 import { connectModule } from '../../../src/index';
 import TodoList from '../components/TodoList';
 
-const mapState = state => ({
-  todos: state.todos.toJS(),
-});
-
 const Connected = connectModule(
-  mapState,
   todoModule
 )(TodoList);
 

--- a/examples/module-with-middleware/modules/todo.js
+++ b/examples/module-with-middleware/modules/todo.js
@@ -1,50 +1,56 @@
-import { createModule } from '../../../src/index';
+import { createModule, middleware } from '../../../src/index';
 import { PropTypes } from 'react';
 import { fromJS, List } from 'immutable';
 import { v4 } from 'uuid';
 
 const { shape, number, string, bool } = PropTypes;
 
+function addUUID({ payload: { todo }, meta, ... rest }) {
+  const id = v4();
+  console.log('Middleware adding ID', id); // eslint-disable-line no-console
+  return {
+    payload: { todo: { ...todo, id } },
+    meta,
+    ... rest,
+  };
+}
+
 export default createModule({
   name: 'todos',
   initialState: List(), // eslint-disable-line new-cap
   transformations: [
     {
-      type: 'CREATE',
-      payloadTypes: {
-        todo: shape({
-          description: string.isRequired,
-        }),
-      },
+      type: 'create',
       middleware: [
-        ({ payload: { todo }, meta, ... rest }) => {
-          const id = v4();
-          console.log('Middleware adding ID', id); // eslint-disable-line no-console
-          return {
-            payload: { todo: { ...todo, id } },
-            meta,
-            ... rest,
-          };
-        },
+        addUUID,
+        middleware.propCheck({
+          todo: shape({
+            description: string.isRequired,
+          }),
+        }),
       ],
       reducer: (state, { payload: { todo } }) => state.push(fromJS(todo)),
     },
     {
-      type: 'DESTROY',
-      payloadTypes: {
-        index: number.isRequired,
-      },
+      type: 'destroy',
+      middleware: [
+        middleware.propCheck({
+          index: number.isRequired,
+        }),
+      ],
       reducer: (state, { payload: { index } }) => state.delete(index),
     },
     {
-      type: 'UPDATE',
-      payloadTypes: {
-        index: number.isRequired,
-        todo: shape({
-          description: string,
-          checked: bool,
+      type: 'update',
+      middleware: [
+        middleware.propCheck({
+          index: number.isRequired,
+          todo: shape({
+            description: string,
+            checked: bool,
+          }),
         }),
-      },
+      ],
       reducer: (state, { payload: { index, todo: updates } }) =>
         state.update(index, todo => todo.merge(fromJS(updates))),
     },

--- a/examples/module-with-middleware/modules/todo.js
+++ b/examples/module-with-middleware/modules/todo.js
@@ -17,6 +17,7 @@ function addUUID({ payload: { todo }, meta, ... rest }) {
 
 export default createModule({
   name: 'todos',
+  selector: state => ({ todos: state.todos.toJS() }),
   initialState: List(), // eslint-disable-line new-cap
   transformations: [
     {

--- a/examples/multi-module/modules/counter.js
+++ b/examples/multi-module/modules/counter.js
@@ -5,11 +5,11 @@ export default createModule({
   initialState: 0,
   transformations: [
     {
-      type: 'INCREMENT',
+      type: 'increment',
       reducer: state => state + 1,
     },
     {
-      type: 'DECREMENT',
+      type: 'decrement',
       reducer: state => state - 1,
     },
   ],

--- a/examples/multi-module/modules/todo.js
+++ b/examples/multi-module/modules/todo.js
@@ -9,36 +9,36 @@ export default createModule({
   initialState: List(), // eslint-disable-line new-cap
   transformations: [
     {
-      type: 'CREATE',
+      type: 'create',
       middleware: [
         middleware.propCheck({
           todo: shape({
             description: string.isRequired,
-            name: string.isRequired,
           }),
         }),
       ],
       reducer: (state, { payload: { todo } }) => state.push(fromJS(todo)),
     },
     {
-      type: 'DESTROY',
+      type: 'destroy',
       middleware: [
         middleware.propCheck({
           index: number.isRequired,
-          test: string.isRequired,
         }),
       ],
       reducer: (state, { payload: { index } }) => state.delete(index),
     },
     {
-      type: 'UPDATE',
-      payloadTypes: {
-        index: number.isRequired,
-        todo: shape({
-          description: string,
-          checked: bool,
+      type: 'update',
+      middleware: [
+        middleware.propCheck({
+          index: number.isRequired,
+          todo: shape({
+            description: string,
+            checked: bool,
+          }),
         }),
-      },
+      ],
       reducer: (state, { payload: { index, todo: updates } }) =>
         state.update(index, todo => todo.merge(fromJS(updates))),
     },

--- a/examples/single-module/modules/todo.js
+++ b/examples/single-module/modules/todo.js
@@ -1,4 +1,4 @@
-import { createModule } from '../../../src/index';
+import { createModule, middleware } from '../../../src/index';
 import { PropTypes } from 'react';
 import { fromJS, List } from 'immutable';
 
@@ -9,30 +9,36 @@ export default createModule({
   initialState: List(), // eslint-disable-line new-cap
   transformations: [
     {
-      type: 'CREATE',
-      payloadTypes: {
-        todo: shape({
-          description: string.isRequired,
+      type: 'create',
+      middleware: [
+        middleware.propCheck({
+          todo: shape({
+            description: string.isRequired,
+          }),
         }),
-      },
+      ],
       reducer: (state, { payload: { todo } }) => state.push(fromJS(todo)),
     },
     {
-      type: 'DESTROY',
-      payloadTypes: {
-        index: number.isRequired,
-      },
+      type: 'destroy',
+      middleware: [
+        middleware.propCheck({
+          index: number.isRequired,
+        }),
+      ],
       reducer: (state, { payload: { index } }) => state.delete(index),
     },
     {
-      type: 'UPDATE',
-      payloadTypes: {
-        index: number.isRequired,
-        todo: shape({
-          description: string,
-          checked: bool,
+      type: 'update',
+      middleware: [
+        middleware.propCheck({
+          index: number.isRequired,
+          todo: shape({
+            description: string,
+            checked: bool,
+          }),
         }),
-      },
+      ],
       reducer: (state, { payload: { index, todo: updates } }) =>
         state.update(index, todo => todo.merge(fromJS(updates))),
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-modules",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "A library for defining clear, boilerplate free Redux reducers.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/createModule/index.js
+++ b/src/createModule/index.js
@@ -13,7 +13,7 @@ const applyReducerEnhancer = (reducer, enhancer) => {
 };
 
 const formatTransformation = (name, { type, ...transformation }) => ({
-  formattedConstant: name ? `${name}/${type}` : type,
+  formattedConstant: `${name}/${type}`,
   type,
   ...transformation,
 });
@@ -64,17 +64,19 @@ export const createModule = ({
     const transformation = formatTransformation(name, finalTransformations[i]);
     const {
         type,
+        namespaced = true,
         formattedConstant,
         reducer,
         middleware = [],
       } = transformation;
 
     const finalMiddleware = [... defaultMiddleware, ... middleware];
+    const constant = namespaced ? formattedConstant : type;
 
     const camelizedActionName = camelize(type);
-    actions[camelizedActionName] = createAction(formattedConstant, finalMiddleware);
-    constants[camelizedActionName] = formattedConstant;
-    reducerMap[formattedConstant] = applyReducerEnhancer(reducer, reducerEnhancer);
+    actions[camelizedActionName] = createAction(constant, finalMiddleware);
+    constants[camelizedActionName] = constant;
+    reducerMap[constant] = applyReducerEnhancer(reducer, reducerEnhancer);
   }
 
   const reducer = (state = initialState, action) => {

--- a/src/createModule/index.js
+++ b/src/createModule/index.js
@@ -84,7 +84,7 @@ export const createModule = ({
     return [
       localReducer,
       ... composes,
-    ].reduce((nState, currentReducer) => currentReducer(nState, action), state);
+    ].reduce((newState, currentReducer) => currentReducer(newState, action), state);
   };
 
   return {

--- a/src/createModule/index.js
+++ b/src/createModule/index.js
@@ -13,7 +13,7 @@ const applyReducerEnhancer = (reducer, enhancer) => {
   return reducer;
 };
 
-const formatTransformation = (name, { type, action, ...transformation }) => ({
+const formatTransformation = (name, { action, type, ...transformation }) => ({
   formattedConstant: `${name}/${type || action}`,
   type: type || action,
   action,

--- a/src/createModule/index.js
+++ b/src/createModule/index.js
@@ -14,8 +14,8 @@ const applyReducerEnhancer = (reducer, enhancer) => {
 };
 
 const formatTransformation = (name, { type, action, ...transformation }) => ({
-  formattedConstant: `${name}/${action || type}`,
-  type: action || type,
+  formattedConstant: `${name}/${type || action}`,
+  type: type || action,
   action,
   ...transformation,
 });


### PR DESCRIPTION
## Description
This branch adds the ability for modules to compose other reducers via the `composes` key in `createModule` as well as the ability to exclude transformations from being namespaced via the optional `namespaced` key in the transformation object.

## Example Usage
```js
import { createModule } from 'redux-modules';
import { liftState, loop, Effects } from 'redux-loop';

const sidebar = createModule({
  name: 'sidebar',
  transformations: [
    {
      type: 'fetch',
      namespaced: false,
      reducer: state => state.set('showSidebarSpinner', true),
    },
  ],
});

const todos = createModule({
  name: 'todos',
  composes: [ sidebar.reducer, liftState ],
  transformations: [
    // returns action with type === `fetch`
    {
      type: 'fetch',
      namespaced: false,
      reducer: state => loop(
        state.set('loading', true), 
        Effects.promise(/* some promise here */)
      )
    },
  ],
});
```