### PR TITLE
Fixed some whitespace, added support for module wide middleware

### DIFF
--- a/src/createModule/index.js
+++ b/src/createModule/index.js
@@ -33,10 +33,12 @@ function parseTransformations(transformations) {
 export default function createModule({
   composes = [],
   initialState,
+  middleware: moduleMiddleware = [],
   name,
   reducerEnhancer,
   selector,
-  transformations }) {
+  transformations,
+}) {
   const finalTransformations = parseTransformations(transformations);
   const actions = {};
   const constants = {};
@@ -52,7 +54,12 @@ export default function createModule({
       type,
     } = formatTransformation(name, finalTransformations[i]);
 
-    const finalMiddleware = [parsePayloadErrors, ...middleware];
+    const finalMiddleware = [
+      parsePayloadErrors,
+      ...middleware,
+      ...moduleMiddleware,
+    ];
+
     const constant = namespaced ? formattedConstant : type;
 
     // DEPRECATION WARNINGS


### PR DESCRIPTION
## Description
Allows use of module wide action creator middleware. Usage includes logging (of course), as well as decorating and inspecting action payloads before they hit the reducer function.

## Example Usage
```js
export default createModule({
  name: 'todos',
  middleware: [ a => { console.log(a); return a; } ],
  transforms: [ ... ],
});
```

Closes #81 