### PR TITLE
Define `transformations` in camelCase.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "deep-assign": "^2.0.0",
     "hoist-non-react-statics": "^1.2.0",
-    "lodash-es": "^4.16.2"
+    "lodash": "^4.16.4"
   },
   "peerDependencies": {
     "redux": "^3.3.1"

--- a/tests/connectModule/multiModule-test.js
+++ b/tests/connectModule/multiModule-test.js
@@ -16,10 +16,10 @@ should();
 const generateMockModule = id => createModule({
   name: `mock${id}`,
   initialState: 0,
-  transformations: [
-    { type: 'INCREMENT', reducer: state => state + 1 },
-    { type: 'DECREMENT', reducer: state => state - 1 },
-  ],
+  transformations: {
+    decrement: state => state - 1,
+    increment: state => state + 1,
+  },
 });
 
 const store = createStore(state => state, {});

--- a/tests/connectModule/singleModule-test.js
+++ b/tests/connectModule/singleModule-test.js
@@ -16,10 +16,10 @@ should();
 const mockModule = createModule({
   name: 'mock',
   initialState: 0,
-  transformations: [
-    { type: 'INCREMENT', reducer: state => state + 1 },
-    { type: 'DECREMENT', reducer: state => state - 1 },
-  ],
+  transformations: {
+    decrement: state => state - 1,
+    increment: state => state + 1,
+  },
 });
 const store = createStore(state => state, {});
 const selector = state => ({ count: state.mock });
@@ -71,7 +71,7 @@ describe('ConnectedComponent', () => {
     const wrapper = mount(
       <ModuleProvider store={store}>
         <div>
-          <Single count={1} dispatch={() => {}} />
+          <Single count={1} dispatch={() => { }} />
         </div>
       </ModuleProvider>
     );

--- a/tests/createModule/createModule-test.js
+++ b/tests/createModule/createModule-test.js
@@ -28,9 +28,8 @@ const generatedModule = createModule({
       return a;
     },
   ],
-  transformations: [
-    {
-      type: 'MOCK_ONE',
+  transformations: {
+    mockOne: {
       middleware: [
         a => {
           transformMiddlewareCalled = true;
@@ -39,8 +38,8 @@ const generatedModule = createModule({
       ],
       reducer: mirrorAction,
     },
-    { type: 'MOCK_TWO', reducer: mirrorAction },
-  ],
+    mockTwo: mirrorAction,
+  },
 });
 
 describe('createModule', () => {

--- a/tests/middleware/payloadPropchecker-test.js
+++ b/tests/middleware/payloadPropchecker-test.js
@@ -62,10 +62,12 @@ describe('propCheck', () => {
   });
 
   it('should throw an error when the payload does not match stated type', () => {
+    // eslint-disable-next-line no-unused-expressions
     objectSpy.calledOnce.should.be.ok;
   });
 
   it('should work when propChecker is given a function instead of an object', () => {
+    // eslint-disable-next-line no-unused-expressions
     funcSpy.calledOnce.should.be.ok;
   });
 


### PR DESCRIPTION
Closes #84, also drops deprecated functionality (defining `type` as `action`, passing `payloadTypes`).  It's a breaking change, so bump to `0.7.0` if you want to accept it.