### PR TITLE
Pruning of modules that are not needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   "dependencies": {
     "deep-assign": "^2.0.0",
     "hoist-non-react-statics": "^1.2.0",
-    "lodash": "^4.16.4"
+    "lodash.map": "^4.6.0",
+    "lodash.snakecase": "^4.1.1"
   },
   "peerDependencies": {
     "redux": "^3.3.1"

--- a/src/createModule/index.js
+++ b/src/createModule/index.js
@@ -1,5 +1,6 @@
 import createAction from './createAction';
-import { defaults, forEach, map, snakeCase } from 'lodash';
+import map from 'lodash.map';
+import snakeCase from 'lodash.snakecase';
 import parsePayloadErrors from '../middleware/parsePayloadErrors';
 
 const defaultReducer = state => state;
@@ -23,7 +24,8 @@ function parseTransformation(transformation, actionName) {
   if (typeof transformation === 'function') {
     return { actionName, reducer: transformation, type };
   }
-  return defaults({}, transformation, { actionName, type });
+
+  return Object.assign({}, transformation, { actionName, type });
 }
 
 export default function createModule({
@@ -39,7 +41,8 @@ export default function createModule({
   const actions = {};
   const constants = {};
   const reducerMap = {};
-  forEach(parsedTransformations,
+
+  parsedTransformations.forEach(
     ({ actionName, middleware = [], namespaced = true, reducer, type }) => {
       const finalMiddleware = [parsePayloadErrors, ...middleware, ...moduleMiddleware];
       const constant = namespaced ? `${name}/${type}` : type;
@@ -47,11 +50,13 @@ export default function createModule({
       constants[actionName] = constant;
       reducerMap[constant] = reducer;
     });
+
   function finalReducer(state = initialState, action) {
     const localReducer = reducerMap[action.type] || defaultReducer;
     return [localReducer, ...composes]
       .reduce((newState, currentReducer) => currentReducer(newState, action), state);
   }
+
   return {
     actions,
     constants,


### PR DESCRIPTION
### With the intentions of making the library lighter

* [x] Removes lodash from package.json
* [x] Adds lodash.map to package.json (this can be removed, need to understand intentions of what it is doing first)
* [x] Adds lodash.snakecase to package.json (could probably be replaced with RegEx)
* [x] Removed _.default in favor of Object.assign({}, ...)